### PR TITLE
Lazy-start Good-For-Day pruning thread

### DIFF
--- a/OrderbookSim/Orderbook.cpp
+++ b/OrderbookSim/Orderbook.cpp
@@ -322,6 +322,12 @@ Trades Orderbook::MatchOrder(OrderModify order) {
     return addOrder(order.toOrderPtr(existingOrder->getOrderType()));
 }
 
+void Orderbook::StartPruneThread() {
+    std::call_once(_pruneThreadOnce, [this] {
+        _ordersPruneThread = std::thread([this] { PruneGoodForDayOrders(); });
+    });
+}
+
 /*!
  * @brief Prunes GoodForDay orders at the end of the trading day.
  *
@@ -455,6 +461,9 @@ Trades Orderbook::addOrder(OrderPtr order) {
 
     if (order->getOrderType() == OrderType::FillAndKill && !canMatch(order->getSide(), order->getPrice())) return { };
     if (order->getOrderType() == OrderType::FillOrKill && !canFullyFill(order->getSide(), order->getPrice(), order->getInitialQty())) return { };
+    if (order->getOrderType() == OrderType::GoodForDay) {
+        StartPruneThread();
+    }
 
     OrderPtrs::iterator iter;
     if (order->getSide() == Side::Buy) {

--- a/OrderbookSim/Orderbook.hpp
+++ b/OrderbookSim/Orderbook.hpp
@@ -82,7 +82,8 @@ private:
     std::unordered_map<Price, LevelData> _data; ///< Data about levels by price.
 
     mutable std::mutex _ordersMutex; ///< Mutex for synchronizing orderbook operations.
-    std::thread _ordersPruneThread; ///< Thread for pruning Good For Day orders.
+    std::thread _ordersPruneThread; ///< Thread for pruning Good For Day orders (lazy-started).
+    std::once_flag _pruneThreadOnce; ///< Ensures the pruning thread starts only once.
     std::condition_variable _shutdownConditionVariable; ///< Condition variable for shutdown signaling.
     std::atomic<bool> _shutdown{ false }; ///< Shutdown flag.
 
@@ -104,15 +105,16 @@ private:
     Trades MatchOrder(OrderModify order);
 
     // Private methods for managing Good For Day orders
+    void StartPruneThread();
     void PruneGoodForDayOrders();
     Trades MatchOrdersUnlocked();
 
 
 public:
     /*!
-     * @brief Default constructor, initializes the Good For Day order pruning thread.
+     * @brief Default constructor.
      */
-    Orderbook() : _ordersPruneThread{ [this] { PruneGoodForDayOrders(); } } {}
+    Orderbook() = default;
 
     // Deleted copy and move constructors and operators to prevent copying
     Orderbook(const Orderbook&) = delete;
@@ -126,7 +128,9 @@ public:
     ~Orderbook() {
         _shutdown.store(true, std::memory_order_release);
         _shutdownConditionVariable.notify_one();
-        _ordersPruneThread.join();
+        if (_ordersPruneThread.joinable()) {
+            _ordersPruneThread.join();
+        }
     }
 
     /*!


### PR DESCRIPTION
### Motivation
- Prevent creating a background pruning thread unless Good-For-Day (GFD) orders are used to avoid unnecessary threads during tests and simple runs.
- Ensure the pruning thread is started at most once to avoid races and duplicate threads.
- Avoid calling `join()` on a thread that was never started to prevent undefined behavior or hangs on shutdown.

### Description
- Replaced eager thread creation in the constructor with `Orderbook() = default;` and added a `std::once_flag _pruneThreadOnce` member.
- Added `StartPruneThread()` which uses `std::call_once` to lazily spawn the pruning thread (`PruneGoodForDayOrders()`).
- Call `StartPruneThread()` when an order of type `OrderType::GoodForDay` is added in `addOrder()`.
- Made shutdown safe by checking `_ordersPruneThread.joinable()` before calling `join()` in the destructor.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6ede2a6883218d65962e1d21dc72)